### PR TITLE
Remove kian id safety net

### DIFF
--- a/src/events/messages/bruh.ts
+++ b/src/events/messages/bruh.ts
@@ -43,7 +43,6 @@ async function handleExistingMutes(client: Client<true>) {
 function test(message: Message): boolean {
 	return (
 		!message.author.bot &&
-		message.author.id !== Users.Kian &&
 		(message.channel.isThread()
 			? message.channel.parentId !== Channels.Announcements
 			: message.channelId !== Channels.Announcements) &&
@@ -71,7 +70,7 @@ async function handleNewMessage(message: Message) {
 		await Promise.all([
 			message.react("🥀"),
 			message.reply(
-				Math.random() < 0.01
+				Math.random() < 0.067
 					? "https://tenor.com/view/bee-movie-layton-t-montgomery-monty-montgomery-67-6-7-gif-9758470031245276788"
 					: "OMG HAHA SO FUNNY SIX AND SEVEN ARE CONSECUTIVE DIGITS 🤯",
 			),

--- a/src/events/messages/bruh.ts
+++ b/src/events/messages/bruh.ts
@@ -8,7 +8,7 @@ import {
 	type PartialMessage,
 } from "discord.js";
 import { env } from "../../env";
-import { Guilds, Roles, Users, Channels } from "../../consts";
+import { Guilds, Roles, Channels } from "../../consts";
 import { extractMessageContext, extractMessageUpdateContext, log, withSentryEventScope } from "../../logging";
 import { addMute, removeMute, getMutes } from "../../db";
 


### PR DESCRIPTION
A statement in `test()` checked if `message.author.id !== Users.Kian`. This means that the user known as Kian never get 67'd and never receives a mute. This feature has been removed in this PR in response to the growing outcries of the `egrass touchers` server for equality.
